### PR TITLE
Allow importing entire repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,4 +177,3 @@ pyrightconfig.json
 
 .vs
 .vscode
-experiment

--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ options:
   -h, --help            show this help message and exit
   --library LIBRARY     The library to search for in the imports. E.g. 'qtpy'.
   --input-dir INPUT_DIR
-                        The directory to search for Python files. E.g. 'C:\path o\sleap'.
+                        The path to the source code of a repo. E.g. 'C:\path\to\sleap'. If no directory is provided, then testing the
+                        repo import is skipped. If a directory is provided without a library argument, then the entire repo is copied
+                        and tested for import-ability. If both a directory and a library are provided, then only the imports from the
+                        library are copied.
   --commit-message COMMIT_MESSAGE
                         The commit message to use when committing the changes.
 ```

--- a/envexp/test_env.py
+++ b/envexp/test_env.py
@@ -41,8 +41,16 @@ def close_logger_handlers(logger):
         logger.removeHandler(handler)
 
 
+# Configure commonly reused paths
+FILE_PATH = Path(__file__)
+FILE_DIR = FILE_PATH.parent
+BASE_DIR = FILE_DIR.parent.absolute()
+
+# Configure gitignore
+GITIGNORE_PATH = BASE_DIR / ".gitignore"
+GITIGNORE_FLAG = "# added by envexp\n"
+
 # Configure the logging module to write logs to a file
-BASE_DIR = Path(__file__).parent.parent.absolute()
 LOGFILE = BASE_DIR / "test.log"
 logging.basicConfig(
     filename=LOGFILE,

--- a/envexp/test_env.py
+++ b/envexp/test_env.py
@@ -319,7 +319,7 @@ def find_and_copy_imports(input_dir, output_path, library):
         if matching_imports:
             relative_path = python_file.relative_to(input_dir)
             with init_path.open("a") as initfile:
-                initfile.write(f"# {relative_path}\n")
+                initfile.write(f"\n# {relative_path}\n")
                 initfile.write("\n".join(matching_imports) + "\n")
 
 

--- a/envexp/test_env.py
+++ b/envexp/test_env.py
@@ -1,10 +1,25 @@
 import argparse
+import inspect
 import logging
-import re
 import shutil
 import subprocess
 import time
 from pathlib import Path
+
+# TODO(LM): Separate test code from the main code
+# from pygments import highlight
+# from pygments.formatters import TerminalFormatter
+# from pygments.lexers import PythonLexer
+
+
+def print_code(code):
+    """Prints code with syntax highlighting."""
+
+    print(code)
+    return
+
+    # TODO(LM): Separate test code from the main code
+    print(highlight(code, PythonLexer(), TerminalFormatter()))
 
 
 def wait_for_log_update(logfile_path, timeout=10):
@@ -40,11 +55,14 @@ logger = logging.getLogger(__name__)
 def determine_conda():
     """Determines the conda executable to use (i.e. mm, mamba, or conda)."""
 
+    print("\nDetermining conda executable...")
+
     # Check if mamba is installed
     try:
         output = subprocess.run("mamba --version", shell=True, capture_output=True)
         if len(output.stderr) > 0:
             raise FileNotFoundError("No mamba executable found.")
+        print("\t... using mamba")
         return "mamba"
     except Exception as e:
         print(output.stderr.decode())
@@ -55,6 +73,7 @@ def determine_conda():
         output = subprocess.run("micromamba --version", shell=True, capture_output=True)
         if len(output.stderr) > 0:
             raise FileNotFoundError("No micromamba executable found.")
+        print("\t... using micromamba")
         return "micromamba"
     except FileNotFoundError:
         pass
@@ -64,6 +83,7 @@ def determine_conda():
         output = subprocess.run("conda --version", shell=True, capture_output=True)
         if len(output.stderr) > 0:
             raise FileNotFoundError("No conda executable found.")
+        print("\t... using conda")
         return "conda"
     except FileNotFoundError:
         pass
@@ -74,6 +94,8 @@ def determine_conda():
 def remove_environment(conda_command):
     """Removes the conda environment created for the experiment."""
 
+    print("\nRemoving experiment environment...")
+
     # Remove the conda environment
     command = f"{conda_command} env remove -n experiment"
     if conda_command == "micromamba":
@@ -83,6 +105,8 @@ def remove_environment(conda_command):
 
 def create_environment(conda_command):
     """Creates a new conda environment with the required dependencies."""
+
+    print("\n(Re)creating experiment environment...")
 
     parent_dir = Path(__file__).resolve().parent
     environment_file = parent_dir / "environment.yml"
@@ -252,6 +276,12 @@ def run_and_log(command, fail_message=None, pass_message=None):
 
 def test_code(conda_command):
     """Runs user-defined test code."""
+
+    logger.info("Running user-defined test code...")
+    print(f"\nRunning user-defined test code:")
+    user_code = inspect.getsource(user_test_code)
+    logger.info(user_code)
+    print_code(user_code)
 
     fail_message = "Tests failed!"
     pass_message = "Tests passed successfully!"

--- a/envexp/test_env.py
+++ b/envexp/test_env.py
@@ -507,7 +507,7 @@ def main(library=None, input_dir=None, repo_name=None, commit_message=None):
     conda_command = determine_conda()
 
     # Remove environment
-    # remove_environment(conda_command=conda_command)
+    remove_environment(conda_command=conda_command)
 
     # Reset log file
     with open(LOGFILE, "w") as f:
@@ -515,7 +515,7 @@ def main(library=None, input_dir=None, repo_name=None, commit_message=None):
 
     try:
         # Create a new conda environment
-        # create_environment(conda_command=conda_command)
+        create_environment(conda_command=conda_command)
 
         # Test the imports
         if input_dir is not None:
@@ -540,12 +540,12 @@ def main(library=None, input_dir=None, repo_name=None, commit_message=None):
         # Commit the changes
         close_logger_handlers(logger)
         wait_for_log_update(LOGFILE)
-        # commit_changes(commit_message=commit_message)
+        commit_changes(commit_message=commit_message)
 
 
 if __name__ == "__main__":
     main(
-        # library="qtpy",
+        library="qtpy",
         repo_name="sleap",
         input_dir="/Users/liezlmaree/Projects/sleap/sleap",
         commit_message="Run test code",

--- a/envexp/test_env.py
+++ b/envexp/test_env.py
@@ -326,7 +326,22 @@ def find_and_copy_imports(input_dir, output_path, library):
 def user_test_code():
     """User-defined test code to run after the imports have been tested."""
 
-    import experiment
+    return
+
+    # Example test code that is not run since after return
+    from qtpy.QtWidgets import QApplication, QMainWindow
+
+    def create_app():
+        """Creates Qt application."""
+        app = QApplication([])
+        return app
+
+    app = create_app()
+
+    window = QMainWindow()
+    window.showMaximized()
+
+    app.exec_()
 
 
 def run_and_log(command, fail_message=None, pass_message=None):

--- a/envexp/test_env.py
+++ b/envexp/test_env.py
@@ -463,7 +463,13 @@ def create_parser():
     parser.add_argument(
         "--input-dir",
         type=str,
-        help="The directory to search for Python files. E.g. 'C:\path\to\sleap'.",
+        help=(
+            "The path to the source code of a repo. E.g. 'C:\path\\to\sleap'. If no "
+            "directory is provided, then testing the repo import is skipped. If a "
+            "directory is provided without a library argument, then the entire "
+            "repo is copied and tested for import-ability. If both a directory and "
+            "a library are provided, then only the imports from the library are copied."
+        ),
         default=None,
     )
     parser.add_argument(

--- a/envexp/test_env.py
+++ b/envexp/test_env.py
@@ -498,7 +498,7 @@ def parse_args(library=None, input_dir=None, repo_name=None, commit_message=None
     if args.input_dir is not None:
         args.input_dir = Path(input_dir)
         if args.repo_name is None:
-            args.repo_name = input_dir.name
+            args.repo_name = args.input_dir.name
 
     # Print the modified arguments
     print(f"Modified Arguments:\n\t{args}")
@@ -567,8 +567,8 @@ def main(library=None, input_dir=None, repo_name=None, commit_message=None):
 
 if __name__ == "__main__":
     main(
-        library="qtpy",
-        repo_name="sleap",
+        # library="qtpy",
+        # repo_name="sleap",
         input_dir="/Users/liezlmaree/Projects/sleap/sleap",
         commit_message="Run test code",
     )

--- a/envexp/test_env.py
+++ b/envexp/test_env.py
@@ -139,13 +139,13 @@ def create_environment(conda_command):
 
 
 def clean_up_envexp():
-    """Removes all directories in ./envexp folder that does not contain "egg-info"."""
+    """Removes all directories in ./envexp folder that does not contain "envexp"."""
 
     print("\nCleaning up envexp directory...")
 
     envexp_dir = Path(__file__).resolve().parent
     for directory in envexp_dir.iterdir():
-        if directory.is_dir() and ("egg-info" not in directory.name):
+        if directory.is_dir() and ("envexp" not in directory.name):
             print(f"Removing directory [{directory}]...")
             shutil.rmtree(directory)
 

--- a/envexp/test_env.py
+++ b/envexp/test_env.py
@@ -467,12 +467,6 @@ def create_parser():
         default=None,
     )
     parser.add_argument(
-        "--repo-name",
-        type=str,
-        help="The name of the repo to copy imports from. E.g. 'sleap'.",
-        default=None,
-    )
-    parser.add_argument(
         "--commit-message",
         type=str,
         help="The commit message to use when committing the changes.",
@@ -480,7 +474,7 @@ def create_parser():
     return parser
 
 
-def parse_args(library=None, input_dir=None, repo_name=None, commit_message=None):
+def parse_args(library=None, input_dir=None, commit_message=None):
     # Parse the command-line arguments
     parser = create_parser()
     args = parser.parse_args()
@@ -491,14 +485,12 @@ def parse_args(library=None, input_dir=None, repo_name=None, commit_message=None
     # Set the arguments
     args.library = library or args.library
     args.input_dir = input_dir or args.input_dir
-    args.repo_name = repo_name or args.repo_name
     args.commit_message = commit_message or args.commit_message
 
     # Modify the input_dir and repo_name if input_dir is provided
     if args.input_dir is not None:
         args.input_dir = Path(input_dir)
-        if args.repo_name is None:
-            args.repo_name = args.input_dir.name
+        repo_name = args.input_dir.name
 
     # Print the modified arguments
     print(f"Modified Arguments:\n\t{args}")
@@ -509,16 +501,15 @@ def parse_args(library=None, input_dir=None, repo_name=None, commit_message=None
             "Missing required argument --commit-message. "
             "Please provide a commit message.",
         )
-    return args.library, args.input_dir, args.repo_name, args.commit_message
+    return args.library, args.input_dir, repo_name, args.commit_message
 
 
-def main(library=None, input_dir=None, repo_name=None, commit_message=None):
+def main(library=None, input_dir=None, commit_message=None):
 
     # Parse the command-line arguments
     library, input_dir, repo_name, commit_message = parse_args(
         library=library,
         input_dir=input_dir,
-        repo_name=repo_name,
         commit_message=commit_message,
     )
 
@@ -567,8 +558,7 @@ def main(library=None, input_dir=None, repo_name=None, commit_message=None):
 
 if __name__ == "__main__":
     main(
-        # library="qtpy",
-        # repo_name="sleap",
+        library="qtpy",
         input_dir="/Users/liezlmaree/Projects/sleap/sleap",
         commit_message="Run test code",
     )

--- a/envexp/test_env.py
+++ b/envexp/test_env.py
@@ -138,66 +138,138 @@ def create_environment(conda_command):
         log_dependencies(conda_command=conda_command)
 
 
-def remove_imports(imports_dir):
-    """Removes the imports directory if it exists."""
-    imports_dir = Path(imports_dir)
-    if imports_dir.exists():
-        print("Removing imports directory...")
-        shutil.rmtree(imports_dir)
+def clean_up_envexp():
+    """Removes all directories in ./envexp folder that does not contain "egg-info"."""
+
+    print("\nCleaning up envexp directory...")
+
+    envexp_dir = Path(__file__).resolve().parent
+    for directory in envexp_dir.iterdir():
+        if directory.is_dir() and ("egg-info" not in directory.name):
+            print(f"Removing directory [{directory}]...")
+            shutil.rmtree(directory)
+
+    un_gitignore_prev_repo()
 
 
-def find_imports(input_dir, repo_name=None, library=None):
+def gitignore_repo(repo_name):
+    """Appends the repo name to the .gitignore file.
+
+    Args:
+        repo_name (str): The name of the repo to append to the .gitignore file.
+    """
+
+    # Ensure the .gitignore file ends with a newline
+    with GITIGNORE_PATH.open("rb+") as file:
+        file.seek(-1, 2)  # Move the cursor to the last byte in the file
+        last_char = file.read(1)
+        if last_char != b"\n":
+            file.write(b"\n")
+
+    with GITIGNORE_PATH.open("a") as gitignore:
+        gitignore.write(f"\n{GITIGNORE_FLAG}{repo_name}/\n")
+
+
+def un_gitignore_prev_repo():
+    """Removes the previous repo name from the .gitignore file."""
+
+    def is_gitignore_block(prev_line, line, next_line):
+        """Determines if the line is part of the gitignore block.
+
+        Args:
+            prev_line (str): The previous line.
+            next_line (str): The next line.
+        """
+
+        if (
+            (GITIGNORE_FLAG in prev_line)
+            or (GITIGNORE_FLAG in line)
+            or (GITIGNORE_FLAG in next_line)
+        ):
+            return True
+        return False
+
+    with GITIGNORE_PATH.open("r") as gitignore:
+        lines = gitignore.readlines()
+
+    with GITIGNORE_PATH.open("w") as gitignore:
+        # Write the first line (we assume it's not part of the block)
+        gitignore.write(lines[0])
+
+        # Only write lines that are not part of the envexp gitignore block
+        for line_idx, line in enumerate(lines[1:-1]):
+
+            prev_line = lines[line_idx]
+            next_line = lines[line_idx + 2]
+            if is_gitignore_block(prev_line, line, next_line):
+                continue
+
+            gitignore.write(line)
+        # Write the last line if it's not part of the block
+        if not is_gitignore_block(prev_line=line, line=next_line, next_line=lines[-1]):
+            gitignore.write(lines[-1])
+
+    return
+
+
+def copy_source_code(input_dir, repo_name, library=None):
     """Finds all imports from a given library in Python files and copies them to test.
 
     Args:
         input_dir (str): The directory to search for Python files.
             E.g. 'C:\path\to\sleap'.
         repo_name (str): The name of the repo to copy imports from. E.g. 'sleap'.
-            If None, then will use the name of the input directory.
         library (str): The library to search for in the imports. E.g. 'qtpy'. If None,
             the function will search for imports all non-tabbed imports.
     """
 
-    current_file = Path(__file__).resolve()
-    output_dir = Path(current_file.parent) / "experiment"  # TODO: Change to repo_name
-
     # Remove the imports directory if it exists
-    remove_imports(imports_dir=output_dir)
+    clean_up_envexp()
 
-    # Set-up input and output paths
-    input_path = Path(input_dir)
-    repo_name = input_path.name
-    output_path = Path(
-        output_dir
-    ).resolve()  # Resolve to absolute path but keep it relative if given so
+    # Set-up output path to copy and test code
+    output_path = FILE_DIR / repo_name
     output_path.mkdir(
         parents=True, exist_ok=True
     )  # Create output directory if it doesn't exist
-    init_path = (
-        output_path / "__init__.py"
-    )  # Create __init__.py file in output directory
 
-    if library is None:
+    gitignore_repo(repo_name)
 
-        def check_import(line):
-            """Check if the line is an import statement."""
-
-            if line.startswith("from ") or line.startswith("import "):
-                return True
-            return False
-
+    # Only find and copy specific imports if a library is provided
+    if library is not None:
+        print(f"\nFinding and copying imports from [{library}]...")
+        find_and_copy_imports(
+            input_dir=input_dir, output_path=output_path, library=library
+        )
+        print(f"Finished copying imports from [{library}].")
     else:
+        print("\nCopying entire repo from input directory...")
+        copy_repo(input_dir=input_dir, output_path=output_path)
+        print("Finished copying entire repo.")
 
-        def check_import(line):
-            """Check if the line is an import statement from the library."""
+    return
 
-            if line.startswith(f"from {library}") or line.startswith(
-                f"import {library}"
-            ):
-                return True
-            return False
 
-    for python_file in input_path.rglob("*.py"):  # Search recursively for Python files
+def copy_repo(input_dir, output_path):
+    """Copies the entire repo to the output path."""
+
+    # Copy the entire repo to the output path
+    shutil.copytree(input_dir, output_path, dirs_exist_ok=True)
+
+
+def find_and_copy_imports(input_dir, output_path, library):
+
+    def is_import(line):
+        """Check if the line is an import statement from the library."""
+
+        if line.startswith(f"from {library}") or line.startswith(f"import {library}"):
+            return True
+        return False
+
+    # Create __init__.py file in output directory to add all imports
+    init_path = output_path / "__init__.py"
+
+    # Find all Python files in the input directory
+    for python_file in input_dir.rglob("*.py"):
         with python_file.open("r") as infile:
             lines = infile.readlines()
 
@@ -206,6 +278,7 @@ def find_imports(input_dir, repo_name=None, library=None):
         multi_line_import = False
         current_import = ""
 
+        # Find imports from the library
         for line in lines:
             if multi_line_import:
                 current_import += line.strip()
@@ -215,13 +288,7 @@ def find_imports(input_dir, repo_name=None, library=None):
                     current_import = ""
                 continue
 
-            if check_import(line):
-
-                # Skip the line if the repo name is in the line
-                if repo_name in re.split(r"[ .,\(\)\n]+", line):
-                    continue
-                    # line = line.replace(repo_name, "experiment")
-
+            if is_import(line):
                 # Determine if the import is a multi-line import
                 if line.strip().endswith("("):
                     multi_line_import = True
@@ -231,20 +298,10 @@ def find_imports(input_dir, repo_name=None, library=None):
 
         # Only write to the output file if there are matching lines
         if matching_imports:
-            # Create the output file path
-            realtive_path = python_file.relative_to(input_path)
-            output_file_path = output_path / realtive_path
-            if not output_file_path.parent.exists():
-                output_file_path.parent.mkdir(parents=True, exist_ok=True)
-            with output_file_path.open("w") as outfile:
-                outfile.write("\n".join(matching_imports) + "\n")
-
-            if library is not None:
-                # Append the output file path to the __init__.py file
-                with init_path.open("a") as initfile:
-                    initfile.write(
-                        f"from {output_path.name} import {python_file.stem}\n"
-                    )
+            relative_path = python_file.relative_to(input_dir)
+            with init_path.open("a") as initfile:
+                initfile.write(f"# {relative_path}\n")
+                initfile.write("\n".join(matching_imports) + "\n")
 
 
 def user_test_code():
@@ -297,13 +354,22 @@ def test_code(conda_command):
     run_and_log(command=command, fail_message=fail_message, pass_message=pass_message)
 
 
-def test_imports(conda_command):
-    """Tests the imports in the experiment environment."""
+def test_imports(conda_command, repo_name):
+    """Tests the imports in the experiment environment.
 
-    # TODO(LM): Change to import the repo name
+    Args:
+        conda_command (str): The conda command to use (i.e. micromamba, mamba, or conda)
+        repo_name (str): The name of the repo to test imports for. E.g. 'sleap'.
+    """
+
+    logger.info("\nTesting imports with:")
+    print("\nTesting imports with:")
+    logger.info(f"\timport {repo_name}")
+    print_code(f"\timport {repo_name}")
+
     fail_message = "Imports failed!"
     pass_message = "Imports passed successfully!"
-    command = f'{conda_command} run -n experiment python -c "import experiment"'
+    command = f'{conda_command} run -n experiment python -c "import {repo_name}"'
     run_and_log(command=command, fail_message=fail_message, pass_message=pass_message)
 
 
@@ -400,14 +466,23 @@ def parse_args(library=None, input_dir=None, repo_name=None, commit_message=None
     parser = create_parser()
     args = parser.parse_args()
 
-    # Set the arguments
-    library = library or args.library
-    input_dir = input_dir or args.input_dir
-    repo_name = repo_name or args.repo_name
-    commit_message = commit_message or args.commit_message
-
     # Print the arguments
-    print(f"Arguments:\n{args}")
+    print(f"CLI Arguments:\n\t{args}")
+
+    # Set the arguments
+    args.library = library or args.library
+    args.input_dir = input_dir or args.input_dir
+    args.repo_name = repo_name or args.repo_name
+    args.commit_message = commit_message or args.commit_message
+
+    # Modify the input_dir and repo_name if input_dir is provided
+    if args.input_dir is not None:
+        args.input_dir = Path(input_dir)
+        if args.repo_name is None:
+            args.repo_name = input_dir.name
+
+    # Print the modified arguments
+    print(f"Modified Arguments:\n\t{args}")
 
     if commit_message is None:
         parser.print_usage()
@@ -415,7 +490,7 @@ def parse_args(library=None, input_dir=None, repo_name=None, commit_message=None
             "Missing required argument --commit-message. "
             "Please provide a commit message.",
         )
-    return library, input_dir, repo_name, commit_message
+    return args.library, args.input_dir, args.repo_name, args.commit_message
 
 
 def main(library=None, input_dir=None, repo_name=None, commit_message=None):
@@ -445,12 +520,12 @@ def main(library=None, input_dir=None, repo_name=None, commit_message=None):
         # Test the imports
         if input_dir is not None:
             # Find imports from library in the given directory
-            find_imports(
+            copy_source_code(
                 input_dir=input_dir,
                 repo_name=repo_name,
                 library=library,
             )
-            test_imports(conda_command=conda_command)
+            test_imports(conda_command=conda_command, repo_name=repo_name)
 
         # Run user-defined test code
         test_code(conda_command=conda_command)

--- a/envexp/test_env.py
+++ b/envexp/test_env.py
@@ -169,6 +169,25 @@ def gitignore_repo(repo_name):
     with GITIGNORE_PATH.open("a") as gitignore:
         gitignore.write(f"\n{GITIGNORE_FLAG}{repo_name}/\n")
 
+    assume_unchanged_gitignore()
+    return
+
+
+def assume_unchanged_gitignore():
+    """Assumes the .gitignore file is unchanged."""
+
+    subprocess.run(
+        "git update-index --assume-unchanged .gitignore", shell=True, cwd=BASE_DIR
+    )
+
+
+def no_assume_unchanged_gitignore():
+    """Removes the assume-unchanged flag from the .gitignore file."""
+
+    subprocess.run(
+        "git update-index --no-assume-unchanged .gitignore", shell=True, cwd=BASE_DIR
+    )
+
 
 def un_gitignore_prev_repo():
     """Removes the previous repo name from the .gitignore file."""
@@ -541,6 +560,9 @@ def main(library=None, input_dir=None, repo_name=None, commit_message=None):
         close_logger_handlers(logger)
         wait_for_log_update(LOGFILE)
         commit_changes(commit_message=commit_message)
+        no_assume_unchanged_gitignore()
+
+    return
 
 
 if __name__ == "__main__":

--- a/envexp/test_env.py
+++ b/envexp/test_env.py
@@ -553,7 +553,7 @@ def main(library=None, input_dir=None, commit_message=None):
 
         # Test the imports
         if input_dir is not None:
-            # Find imports from library in the given directory
+            # Copy imports from the given directory
             copy_source_code(
                 input_dir=input_dir,
                 repo_name=repo_name,

--- a/envexp/test_env.py
+++ b/envexp/test_env.py
@@ -511,6 +511,24 @@ def parse_args(library=None, input_dir=None, commit_message=None):
 
 
 def main(library=None, input_dir=None, commit_message=None):
+    """Main function to run the environment experiment.
+
+    This function:
+        1. removes any existing environment called 'experiment'
+        2. creates a new environment called 'experiment' from the envexp/environment.yml
+        3. logs the dependencies of the experiment environment to mamaba_list.txt and
+            pipdeptree.txt
+        3. copies the source code from the input directory to the envexp directory
+        4. tests the importability of the copied source code
+        5. runs user-defined test code
+        6. logs results of the experiment to test.log
+        7. commits the changes to the root directory
+
+    Args:
+        library (str): The library to search for in the imports. E.g. 'qtpy'.
+        input_dir (str): The path to the source code of a repo. E.g. 'C:\path\\to\sleap'.
+        commit_message (str): The commit message to use when committing the changes.
+    """
 
     # Parse the command-line arguments
     library, input_dir, repo_name, commit_message = parse_args(


### PR DESCRIPTION
Previously, we only allowed copying a subset of import lines from a given source code input directory. But, now we want to test whether importing the entire repo works. Since we read through every line of all python files anyway, we may as well just copy the entire source code directory over.

This PR does a pretty bug overhaul that not only allows importing the entire repo, but also 
- [x] changes the way we copy imports from a specific library (all imports are copied into a single file instead of different files)
- [x] uses the name of the input directory as the name of the output directory when copying imports (instead of "experiment")
- [x] adds the input directory name to the .gitignore
- [x] removes all directories that do not contain "envexp" in their name upon clean-up when starting a new experiment